### PR TITLE
update forum links

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ Code to simulate the security of routing Quorums under various conditions.
 |:---:|:----:|
 |[![Build Status](https://travis-ci.org/maidsafe/routing_sims.svg?branch=master)](https://travis-ci.org/maidsafe/routing_sims)|[![Stories in Ready](https://badge.waffle.io/maidsafe/routing_sims.png?label=ready&title=Ready)](https://waffle.io/maidsafe/routing_sims)|
 
-| [MaidSafe website](http://maidsafe.net) | [SAFE Network Forum](https://forum.safenetwork.io) |
-|:------:|:-------:|
+| [MaidSafe website](https://maidsafe.net) | [SAFE Dev Forum](https://forum.safedev.org) | [SAFE Network Forum](https://safenetforum.org) |
+|:------:|:-------:|:-------:|
 
 ## Outputs
 
@@ -35,7 +35,7 @@ Three tools are available, calculating the output probabilities in different way
 
 Two types of quorum are implemented:
 
-1.  SimpleQuorum — quorum is achieved when the given proportion of nodes send a response 
+1.  SimpleQuorum — quorum is achieved when the given proportion of nodes send a response
 2.  AgeQuorum — quorum requires both the given proportion of nodes and the given proportion
     of sum of the nodes ages.
 


### PR DESCRIPTION
As explained in [this topic](https://safenetforum.org/t/please-update-your-forum-bookmark-to-safenetforum-org/11358), the previous URL is no longer working. The new URL of the SAFE Network Forum is [safenetforum.org](https://safenetforum.org/).

I also added a link to the new [Dev Forum](https://forum.safedev.org/).